### PR TITLE
Fix: Export defaultValueComputed only added if type is 'int' or 'long'

### DIFF
--- a/packages/vuerd/src/core/parser/JSONToLiquibase.ts
+++ b/packages/vuerd/src/core/parser/JSONToLiquibase.ts
@@ -1,3 +1,4 @@
+import { getPrimitiveType } from '@/core/generator/code/helper';
 import { getData } from '@/core/helper';
 import { Logger } from '@/core/logger';
 import {
@@ -15,6 +16,7 @@ import {
   FormatTableOptions,
   generateSeqName,
   KeyColumn,
+  mapppingTranslationsDatabase,
   supportedDialects,
   translate,
   XMLNode,
@@ -514,7 +516,15 @@ export const formatColumn = ({
     });
 
   if (column.option.autoIncrement) {
-    if (dialect === 'postgresql') {
+    const primitive = getPrimitiveType(
+      column.dataType,
+      mapppingTranslationsDatabase[dialect]
+    );
+
+    if (
+      dialect === 'postgresql' &&
+      (primitive === 'int' || primitive === 'long')
+    ) {
       columnXML.addAttribute({
         name: 'defaultValueComputed',
         value: `nextval('${generateSeqName(

--- a/packages/vuerd/src/core/parser/helper.ts
+++ b/packages/vuerd/src/core/parser/helper.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@/core/logger';
 import { Statement } from '@/core/parser/index';
 import { Translation, translations } from '@/core/parser/translations';
+import { Database } from '@@types/engine/store/canvas.state';
 import { Relationship } from '@@types/engine/store/relationship.state';
 import { RelationshipState } from '@@types/engine/store/relationship.state';
 import { Column, Index, Table } from '@@types/engine/store/table.state';
@@ -209,4 +210,13 @@ export const generateSeqName = (
   columnName: string
 ): string => {
   return `${tableName}_${columnName}_seq`.toLowerCase();
+};
+
+export const mapppingTranslationsDatabase: Record<Dialect, Database> = {
+  postgresql: 'PostgreSQL',
+  mssql: 'MSSQL',
+  oracle: 'Oracle',
+
+  liquibase: 'MySQL',
+  unsupportedDatabase: 'MySQL',
 };


### PR DESCRIPTION
### Fix
- When exporting `autoIncrement` in `postresql`, `defaultValueComputed` is now only added when `primitiveType` equals `int` or `long`